### PR TITLE
Add deploy branch to space github action

### DIFF
--- a/.github/workflows/deploy-branch-to-space.yml
+++ b/.github/workflows/deploy-branch-to-space.yml
@@ -1,0 +1,132 @@
+name: Deploy branch to space
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch you wish to create a build from
+        required: true
+        default: main
+      space:
+        description: The space you wish to deploy to
+        required: true
+        default: sandbox
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-runner:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_IMAGE: alphagov/digital-form-builder/runner
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set environment variables
+        run: |
+          echo "DOCKER_IMAGE_TAG=${{ env.REGISTRY }}/${{ env.DOCKER_IMAGE }}:$GITHUB_SHA" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            ${{ env.DOCKER_IMAGE_TAG }}
+          push: true
+          file: runner/Dockerfile
+          build-args: |
+            COMMIT_SHA=$GITHUB_SHA
+
+      - name: Install cloudfoundary
+        shell: bash
+        id: install-cf-cli
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf8-cli
+
+      - name: Deploy to Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        run: |
+          cf api ${{ secrets.CF_API }}
+          cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
+          cf target -o ${{ secrets.CF_ORGANISATION }} -s ${{ github.event.inputs.space }}
+          CF_DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }} cf push -f ./runner/manifest.yml \
+            --docker-image ${{ env.DOCKER_IMAGE_TAG }} \
+            --docker-username ${{ github.actor }}
+
+  build-designer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_IMAGE: alphagov/digital-form-builder/designer
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set environment variables
+        run: |
+          echo "DOCKER_IMAGE_TAG=${{ env.REGISTRY }}/${{ env.DOCKER_IMAGE }}:$GITHUB_SHA" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            ${{ env.DOCKER_IMAGE_TAG }}
+          push: true
+          file: designer/Dockerfile
+          build-args: |
+            COMMIT_SHA=$GITHUB_SHA
+
+      - name: Install cloudfoundary
+        shell: bash
+        id: install-cf-cli
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf8-cli
+
+      - name: Deploy to Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        run: |
+          cf api ${{ secrets.CF_API }}
+          cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
+          cf target -o ${{ secrets.CF_ORGANISATION }} -s ${{ github.event.inputs.space }}
+          CF_DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }} cf push -f ./designer/manifest.yml \
+            --docker-image ${{ env.DOCKER_IMAGE_TAG }} \
+            --docker-username ${{ github.actor }} \
+            --var FORMS_API_URL=${{ secrets.FORMS_API_URL }} \
+            --var PUBLISH_URL=${{ secrets.PUBLISH_URL }} \
+            --var PREVIEW_URL=${{ secrets.PREVIEW_URL }}


### PR DESCRIPTION
To aid in deploying spikes this creates a github action to deploy a branch to a space manually. This should let us deploy branches easily.

### Notes

- This will require you to set up a space and give the service account access to that space ahead of running the action
- This does not change the deploys, if your branch requires any new environment variables you will need to specify them manually using the `cf set-env` command locally
- Currently this does not handle defining the app name, and will deploy everything as defined in the manifest on the `main` branch. If this causes conflicts, we can update it in a subsequent PR to allow for defining the app-prefix (or auto-prefix it based on the name e.g. `cifu-xgov-branchname-runner`)